### PR TITLE
templates/index.html: Fix typo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -64,12 +64,12 @@ documentation will focus on creating templates using&nbsp;jinja2.</p>
 <p>If you are not familiar with jinja2 its a good idea to go through the
 <a href="http://jinja.pocoo.org/docs/templates/">most excellent jinja2 documentation</a>.</p>
 <h2 id="site_structure">Site&nbsp;structure</h2>
-<p>Hyde encourages sepration of content from layout. The following shows a
+<p>Hyde encourages separation of content from layout. The following shows a
 typical structure of a hyde website.
 <div class="codebox"><figure class="code"><div class="highlight"><pre>- content<br />    - media<br />        - css<br />        - js<br />        - images<br />    about.html<br />    index.html<br />    - blog<br />    - projects<br />    - portfolio<br />- layout<br />    base.j2<br />    macros.j2<br />site.yaml<br /></pre></div><br /><figcaption>Bash</figcaption></figure></div></p>
 <p>A good objective is to have all the files in content contain as little layout
 as possible and be written with a text oriented markup language like
-<code>markdown</code>. While its not always possible to achieve 100% sepration, hyde
+<code>markdown</code>. While its not always possible to achieve 100% separation, hyde
 provides several nice tools to get very close to that&nbsp;goal.</p>
 <h2 id="context_variables">Context&nbsp;Variables</h2>
 <p>Hyde by default makes the following variables available for&nbsp;templates:</p>


### PR DESCRIPTION
Change "sepration" to "separation" (two times)
